### PR TITLE
Hymn Remaker Pipeline Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+env/
+venv/
+pip-log.txt
+pip-delete-this-directory.txt
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.log
+.git
+.mypy_cache
+.pytest_cache
+.hypotheses
+
+# Local configuration
+.env
+client_secrets.json
+token.json
+
+# Build artifacts
+dist/
+build/
+*.egg-info/
+
+# Generated files
+hymn_remaker/output/
+temp_art.png

--- a/hymn_remaker/.env.example
+++ b/hymn_remaker/.env.example
@@ -1,0 +1,8 @@
+# Replicate API Token for Music Generation (MusicGen)
+REPLICATE_API_TOKEN=your_replicate_api_token_here
+
+# OpenAI API Key for Metadata and Album Art (GPT-4, DALL-E 3)
+OPENAI_API_KEY=your_openai_api_key_here
+
+# Path to Client Secrets file for YouTube Upload (JSON file downloaded from Google Cloud Console)
+GOOGLE_CLIENT_SECRETS_FILE=client_secrets.json

--- a/hymn_remaker/README.md
+++ b/hymn_remaker/README.md
@@ -1,0 +1,86 @@
+# Hymn Remaker Pipeline
+
+This project is an automated pipeline that takes public domain MIDI hymn files and transforms them into modern "Deep House" (or other styles) music videos for YouTube.
+
+## Overview
+
+The pipeline consists of the following stages:
+
+1.  **MIDI Rendering**: Converts the input `.mid` file into a high-quality `.wav` file using FluidSynth and a SoundFont.
+2.  **Music Remaking**: Uses Replicate's API (specifically Meta's `musicgen-melody`) to generate a remix conditioned on the melody of the rendered audio.
+3.  **Content Generation**: Uses OpenAI's GPT-4 to generate video metadata (title, description, tags) and DALL-E 3 to generate album art.
+4.  **Video Production**: Combines the remix audio and generated album art into an MP4 video using FFmpeg.
+5.  **YouTube Upload**: (Optional) Uploads the generated video to YouTube using the YouTube Data API.
+
+## Prerequisites
+
+### System Dependencies
+
+You need to have `fluidsynth` and `ffmpeg` installed on your system.
+
+**Ubuntu/Debian:**
+```bash
+sudo apt-get update
+sudo apt-get install -y fluidsynth fluid-soundfont-gm ffmpeg
+```
+
+**macOS (Homebrew):**
+```bash
+brew install fluid-synth ffmpeg
+```
+
+### Python Dependencies
+
+Install the required Python packages:
+
+```bash
+pip install -r requirements.txt
+```
+
+### API Keys & Credentials
+
+Create a `.env` file in the `hymn_remaker` directory (see `.env.example`) with the following keys:
+
+-   `REPLICATE_API_TOKEN`: Your API token from [Replicate](https://replicate.com/).
+-   `OPENAI_API_KEY`: Your API key from [OpenAI](https://openai.com/).
+-   `GOOGLE_CLIENT_SECRETS_FILE`: Path to your `client_secrets.json` file for the Google/YouTube API.
+
+**Note:** To upload to YouTube, you must create a project in the [Google Cloud Console](https://console.cloud.google.com/), enable the YouTube Data API v3, and download the OAuth 2.0 Client ID JSON file. Rename it to `client_secrets.json` and place it in the project root.
+
+## Usage
+
+Place your MIDI files in the `hymn_remaker/input/` directory.
+
+Run the pipeline:
+
+```bash
+python3 hymn_remaker/main.py
+```
+
+### Options
+
+-   `--input-dir`: Directory containing input MIDI files (default: `hymn_remaker/input`).
+-   `--output-dir`: Directory for output files (default: `hymn_remaker/output`).
+-   `--soundfont`: Path to a custom SoundFont (`.sf2`) file.
+-   `--style`: Musical style prompt for the remake (default: "Deep House, high quality, electronic").
+-   `--upload`: Upload the generated video to YouTube.
+-   `--skip-render`: Skip rendering if the base audio file already exists.
+-   `--skip-remake`: Skip generation if the remake audio file already exists.
+
+### Example
+
+```bash
+python3 hymn_remaker/main.py --style "Lofi hip hop, chill, relaxing" --upload
+```
+
+## Structure
+
+-   `src/midi_renderer.py`: Handles MIDI to audio conversion.
+-   `src/remaker.py`: Interfaces with Replicate for music generation.
+-   `src/content_generator.py`: Interfaces with OpenAI for text/image generation.
+-   `src/video_uploader.py`: Handles video creation and YouTube upload.
+-   `main.py`: Main orchestration script.
+
+## License
+
+MIT

--- a/hymn_remaker/main.py
+++ b/hymn_remaker/main.py
@@ -1,0 +1,121 @@
+import os
+import sys
+import glob
+import logging
+import argparse
+import json
+import requests
+from dotenv import load_dotenv
+
+# Add the project root to sys.path so we can import from src
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from src.midi_renderer import MidiRenderer
+from src.remaker import MusicRemaker
+from src.content_generator import ContentGenerator
+from src.video_uploader import VideoProducer
+
+# Load environment variables
+load_dotenv()
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.StreamHandler(),
+        # logging.FileHandler("hymn_remaker.log") # Commented out to avoid permission issues if run in weird places
+    ]
+)
+logger = logging.getLogger("HymnRemaker")
+
+def main():
+    parser = argparse.ArgumentParser(description="Hymn Remaker Pipeline")
+    parser.add_argument("--input-dir", default="hymn_remaker/input", help="Directory containing input MIDI files")
+    parser.add_argument("--output-dir", default="hymn_remaker/output", help="Directory for output files")
+    parser.add_argument("--soundfont", help="Path to custom soundfont")
+    parser.add_argument("--style", default="Deep House, high quality, electronic", help="Musical style prompt for the remake")
+    parser.add_argument("--upload", action="store_true", help="Upload to YouTube after generation")
+    parser.add_argument("--skip-render", action="store_true", help="Skip MIDI rendering if WAV exists")
+    parser.add_argument("--skip-remake", action="store_true", help="Skip music generation if output audio exists")
+
+    args = parser.parse_args()
+
+    # Ensure output directory exists
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    # Initialize modules
+    try:
+        renderer = MidiRenderer(soundfont_path=args.soundfont)
+        remaker = MusicRemaker()
+        content_gen = ContentGenerator()
+        video_producer = VideoProducer()
+    except Exception as e:
+        logger.error(f"Failed to initialize pipeline: {e}")
+        sys.exit(1)
+
+    # Find MIDI files
+    midi_files = glob.glob(os.path.join(args.input_dir, "*.mid"))
+    if not midi_files:
+        logger.warning(f"No MIDI files found in {args.input_dir}")
+        sys.exit(0)
+
+    logger.info(f"Found {len(midi_files)} MIDI files to process.")
+
+    for midi_path in midi_files:
+        try:
+            filename = os.path.basename(midi_path)
+            name_no_ext = os.path.splitext(filename)[0]
+            logger.info(f"Processing {filename}...")
+
+            # 1. Render MIDI to Audio (WAV)
+            base_audio_path = os.path.join(args.output_dir, f"{name_no_ext}_base.wav")
+            if not args.skip_render or not os.path.exists(base_audio_path):
+                renderer.render(midi_path, base_audio_path)
+            else:
+                logger.info(f"Skipping render for {filename}, {base_audio_path} exists.")
+
+            # 2. Generate Remake (MusicGen)
+            remake_audio_path = os.path.join(args.output_dir, f"{name_no_ext}_remake.wav")
+
+            if not args.skip_remake or not os.path.exists(remake_audio_path):
+                # Call Replicate
+                remake_url = remaker.remake(base_audio_path, args.style)
+
+                # Download the remake
+                logger.info(f"Downloading remake from {remake_url}...")
+                response = requests.get(remake_url)
+                response.raise_for_status()
+                with open(remake_audio_path, "wb") as f:
+                    f.write(response.content)
+            else:
+                 logger.info(f"Skipping remake for {filename}, {remake_audio_path} exists.")
+
+            # 3. Generate Content (Metadata & Art)
+            # We can do this in parallel, but sequential is safer for now
+            metadata = content_gen.generate_metadata(name_no_ext, style=args.style)
+
+            art_prompt = f"Abstract album art for {metadata.get('title', name_no_ext)}, {args.style} style, high quality, 4k"
+            art_url = content_gen.generate_art(art_prompt)
+
+            # Save metadata to file for reference
+            metadata_path = os.path.join(args.output_dir, f"{name_no_ext}_metadata.json")
+            with open(metadata_path, "w") as f:
+                json.dump(metadata, f, indent=4)
+
+            # 4. Create Video
+            video_path = os.path.join(args.output_dir, f"{name_no_ext}.mp4")
+            video_producer.create_video(remake_audio_path, art_url, video_path)
+
+            # 5. Upload to YouTube (Optional)
+            if args.upload:
+                video_id = video_producer.upload_to_youtube(video_path, metadata)
+                logger.info(f"Video uploaded: https://youtu.be/{video_id}")
+
+            logger.info(f"Finished processing {filename}")
+
+        except Exception as e:
+            logger.error(f"Error processing {midi_path}: {e}")
+            continue
+
+if __name__ == "__main__":
+    main()

--- a/hymn_remaker/requirements.txt
+++ b/hymn_remaker/requirements.txt
@@ -1,0 +1,8 @@
+midi2audio
+replicate
+openai
+google-api-python-client
+google-auth-oauthlib
+google-auth-httplib2
+python-dotenv
+Pillow

--- a/hymn_remaker/scripts/create_test_midi.py
+++ b/hymn_remaker/scripts/create_test_midi.py
@@ -1,0 +1,28 @@
+import struct
+
+def create_simple_midi(filename):
+    # SMF Header: MThd, len=6, format=0, tracks=1, division=96
+    header = b'MThd\x00\x00\x00\x06\x00\x00\x00\x01\x00\x60'
+
+    # Track Data
+    # Delta-time, Event
+    # 00 90 3C 40 (Note On, Middle C, Velocity 64)
+    # 60 80 3C 40 (Note Off after 96 ticks)
+    # 00 FF 2F 00 (End of Track)
+    track_events = (
+        b'\x00\x90\x3C\x40'  # Note On C4
+        b'\x60\x80\x3C\x40'  # Note Off C4
+        b'\x00\xFF\x2F\x00'  # End of Track
+    )
+
+    # Track Header: MTrk, length
+    track_len = struct.pack('>I', len(track_events))
+    track_chunk = b'MTrk' + track_len + track_events
+
+    with open(filename, 'wb') as f:
+        f.write(header + track_chunk)
+
+    print(f"Created {filename}")
+
+if __name__ == "__main__":
+    create_simple_midi("hymn_remaker/input/test_hymn.mid")

--- a/hymn_remaker/src/content_generator.py
+++ b/hymn_remaker/src/content_generator.py
@@ -1,0 +1,106 @@
+import os
+import openai
+import logging
+import json
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+class ContentGenerator:
+    def __init__(self, api_key=None):
+        """
+        Initialize the ContentGenerator with an OpenAI API key.
+
+        Args:
+            api_key (str): OpenAI API key. Defaults to OPENAI_API_KEY env var.
+        """
+        self.api_key = api_key or os.environ.get("OPENAI_API_KEY")
+        if not self.api_key:
+            logger.warning("OPENAI_API_KEY not set. ContentGenerator will not function.")
+
+        if self.api_key:
+            self.client = openai.OpenAI(api_key=self.api_key)
+
+    def generate_metadata(self, hymn_name, style="Deep House"):
+        """
+        Generate title, description, and tags using GPT-4.
+
+        Args:
+            hymn_name (str): Name of the original hymn.
+            style (str): The musical style of the remake.
+
+        Returns:
+            dict: {
+                "title": str,
+                "description": str,
+                "tags": list
+            }
+        """
+        prompt = (
+            f"Generate metadata for a YouTube video featuring a {style} remake of the hymn '{hymn_name}'.\n"
+            f"Provide the following fields in JSON format:\n"
+            f"1. title: A catchy, modern title for the video.\n"
+            f"2. description: A compelling description (max 1000 chars) explaining the remake.\n"
+            f"3. tags: A list of 10 relevant tags."
+        )
+
+        try:
+            logger.info(f"Generating metadata for '{hymn_name}'...")
+            response = self.client.chat.completions.create(
+                model="gpt-4-turbo",  # Using a model that supports JSON mode
+                messages=[
+                    {"role": "system", "content": "You are a creative content strategist for a music channel. You must respond in valid JSON."},
+                    {"role": "user", "content": prompt}
+                ],
+                response_format={ "type": "json_object" }
+            )
+
+            content = response.choices[0].message.content
+            metadata = json.loads(content)
+            logger.info("Metadata generated successfully.")
+            return metadata
+
+        except Exception as e:
+            logger.error(f"Failed to generate metadata: {e}")
+            raise
+
+    def generate_art(self, prompt):
+        """
+        Generate album art using DALL-E 3.
+
+        Args:
+            prompt (str): Description for the image.
+
+        Returns:
+            str: URL of the generated image.
+        """
+        try:
+            logger.info(f"Generating album art for prompt: '{prompt}'...")
+            response = self.client.images.generate(
+                model="dall-e-3",
+                prompt=prompt,
+                size="1024x1024",
+                quality="standard",
+                n=1,
+            )
+
+            image_url = response.data[0].url
+            logger.info(f"Album art generated: {image_url}")
+            return image_url
+
+        except Exception as e:
+            logger.error(f"Failed to generate art: {e}")
+            raise
+
+if __name__ == "__main__":
+    if os.environ.get("OPENAI_API_KEY"):
+        generator = ContentGenerator()
+        # Test metadata
+        import sys
+        if len(sys.argv) > 1:
+            hymn = sys.argv[1]
+            print(generator.generate_metadata(hymn))
+        else:
+            print("Usage: python content_generator.py <hymn_name>")
+    else:
+        print("OPENAI_API_KEY not set. Skipping real test.")

--- a/hymn_remaker/src/midi_renderer.py
+++ b/hymn_remaker/src/midi_renderer.py
@@ -1,0 +1,70 @@
+import os
+from midi2audio import FluidSynth
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+class MidiRenderer:
+    def __init__(self, soundfont_path=None):
+        """
+        Initialize the MidiRenderer with a soundfont.
+
+        Args:
+            soundfont_path (str): Path to the .sf2 soundfont file.
+                                  Defaults to '/usr/share/sounds/sf2/FluidR3_GM.sf2' if not provided.
+        """
+        if soundfont_path:
+            self.soundfont_path = soundfont_path
+        else:
+            # Try to find a default soundfont
+            default_paths = [
+                '/usr/share/sounds/sf2/FluidR3_GM.sf2',
+                '/usr/share/sounds/sf2/default-GM.sf2',
+                '/usr/share/soundfonts/default.sf2'
+            ]
+            for path in default_paths:
+                if os.path.exists(path):
+                    self.soundfont_path = path
+                    break
+            else:
+                raise FileNotFoundError("No default soundfont found. Please provide a path to a valid .sf2 file.")
+
+        logger.info(f"Using SoundFont: {self.soundfont_path}")
+        self.fs = FluidSynth(self.soundfont_path)
+
+    def render(self, midi_path, output_path):
+        """
+        Render a MIDI file to audio (WAV/MP3/FLAC depending on extension).
+
+        Args:
+            midi_path (str): Path to the input MIDI file.
+            output_path (str): Path to the output audio file.
+        """
+        if not os.path.exists(midi_path):
+            raise FileNotFoundError(f"MIDI file not found: {midi_path}")
+
+        logger.info(f"Rendering {midi_path} to {output_path}...")
+
+        try:
+            # midi2audio mainly supports play_midi (to speakers) or midi_to_audio (to file)
+            # The output format is determined by the file extension if midi2audio supports it,
+            # but usually it renders to WAV and then converts if needed.
+            # midi2audio uses 'flac' by default if not specified in method name, but let's check.
+            # Actually midi2audio has `midi_to_audio(midi_file, audio_file)`
+
+            self.fs.midi_to_audio(midi_path, output_path)
+            logger.info("Rendering complete.")
+
+        except Exception as e:
+            logger.error(f"Failed to render MIDI: {e}")
+            raise
+
+if __name__ == "__main__":
+    # Test execution
+    import sys
+    if len(sys.argv) > 2:
+        renderer = MidiRenderer()
+        renderer.render(sys.argv[1], sys.argv[2])
+    else:
+        print("Usage: python midi_renderer.py <input.mid> <output.wav>")

--- a/hymn_remaker/src/remaker.py
+++ b/hymn_remaker/src/remaker.py
@@ -1,0 +1,76 @@
+import os
+import replicate
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+class MusicRemaker:
+    def __init__(self, api_token=None):
+        """
+        Initialize the MusicRemaker with a Replicate API token.
+
+        Args:
+            api_token (str): Replicate API token. Defaults to REPLICATE_API_TOKEN env var.
+        """
+        self.api_token = api_token or os.environ.get("REPLICATE_API_TOKEN")
+        if not self.api_token:
+            logger.warning("REPLICATE_API_TOKEN not set. MusicRemaker will not function.")
+
+        # Authenticate (though replicate client usually does this automatically from env)
+        if self.api_token:
+            os.environ["REPLICATE_API_TOKEN"] = self.api_token
+
+    def remake(self, audio_path, prompt, duration=30):
+        """
+        Generate a remake of the input audio using MusicGen via Replicate.
+
+        Args:
+            audio_path (str): Path to the input audio file (WAV/MP3).
+            prompt (str): Text prompt for the style (e.g. "Deep House, high quality, electronic").
+            duration (int): Duration of the output in seconds.
+
+        Returns:
+            str: URL of the generated audio.
+        """
+        if not os.path.exists(audio_path):
+            raise FileNotFoundError(f"Input audio file not found: {audio_path}")
+
+        logger.info(f"Remaking {audio_path} with prompt: '{prompt}'...")
+
+        try:
+            # Using meta/musicgen-melody which is good for conditioning on input melody
+            # The model hash might change, so checking replicate's latest
+            # This is musicgen-melody
+            model = "meta/musicgen:671ac904629c9798ddc38d7747750e2f54e63d179aa2e84786d1a2d6cc7809a6"
+
+            # Replicate expects a file object for input
+            with open(audio_path, "rb") as audio_file:
+                output = replicate.run(
+                    model,
+                    input={
+                        "prompt": prompt,
+                        "input_audio": audio_file,
+                        "duration": duration,
+                        "model_version": "melody", # Specific for melody conditioning
+                        "normalization_strategy": "peak"
+                    }
+                )
+
+            logger.info(f"Generation complete. Output: {output}")
+            return output
+
+        except Exception as e:
+            logger.error(f"Failed to generate music: {e}")
+            raise
+
+if __name__ == "__main__":
+    if os.environ.get("REPLICATE_API_TOKEN"):
+        remaker = MusicRemaker()
+        import sys
+        if len(sys.argv) > 2:
+            print(remaker.remake(sys.argv[1], sys.argv[2]))
+        else:
+            print("Usage: python remaker.py <input.wav> <prompt>")
+    else:
+        print("REPLICATE_API_TOKEN not set. Skipping real test.")

--- a/hymn_remaker/src/utils.py
+++ b/hymn_remaker/src/utils.py
@@ -1,0 +1,33 @@
+import time
+import logging
+from functools import wraps
+
+logger = logging.getLogger(__name__)
+
+def retry_request(max_retries=3, delay=1, backoff=2, exceptions=(Exception,)):
+    """
+    Decorator to retry a function call with exponential backoff.
+
+    Args:
+        max_retries (int): Maximum number of retries.
+        delay (int): Initial delay in seconds.
+        backoff (int): Multiplier for delay after each failure.
+        exceptions (tuple): Tuple of exceptions to catch and retry on.
+    """
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            current_delay = delay
+            for attempt in range(max_retries + 1):
+                try:
+                    return func(*args, **kwargs)
+                except exceptions as e:
+                    if attempt == max_retries:
+                        logger.error(f"Function {func.__name__} failed after {max_retries} retries. Error: {e}")
+                        raise
+
+                    logger.warning(f"Function {func.__name__} failed (attempt {attempt+1}/{max_retries}). Retrying in {current_delay}s... Error: {e}")
+                    time.sleep(current_delay)
+                    current_delay *= backoff
+        return wrapper
+    return decorator

--- a/hymn_remaker/tests/test_content_generator.py
+++ b/hymn_remaker/tests/test_content_generator.py
@@ -1,0 +1,60 @@
+import unittest
+import os
+import sys
+import json
+from unittest.mock import patch, MagicMock
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from hymn_remaker.src.content_generator import ContentGenerator
+
+class TestContentGenerator(unittest.TestCase):
+    def test_missing_api_key(self):
+        with patch.dict(os.environ, {}, clear=True):
+            gen = ContentGenerator()
+            self.assertIsNone(gen.api_key)
+
+    @patch('hymn_remaker.src.content_generator.openai.OpenAI')
+    def test_generate_metadata(self, MockOpenAI):
+        # Setup mock client
+        mock_client = MockOpenAI.return_value
+
+        # Mock chat.completions.create
+        mock_response = MagicMock()
+        mock_response.choices[0].message.content = json.dumps({
+            "title": "Test Title",
+            "description": "Test Desc",
+            "tags": ["tag1", "tag2"]
+        })
+        mock_client.chat.completions.create.return_value = mock_response
+
+        gen = ContentGenerator(api_key="dummy_key")
+        metadata = gen.generate_metadata("Test Hymn", "Rock")
+
+        self.assertEqual(metadata["title"], "Test Title")
+        self.assertEqual(metadata["description"], "Test Desc")
+        self.assertEqual(metadata["tags"], ["tag1", "tag2"])
+
+        mock_client.chat.completions.create.assert_called_once()
+        call_args = mock_client.chat.completions.create.call_args[1]
+        self.assertEqual(call_args["model"], "gpt-4-turbo")
+        self.assertEqual(call_args["response_format"], { "type": "json_object" })
+
+    @patch('hymn_remaker.src.content_generator.openai.OpenAI')
+    def test_generate_art(self, MockOpenAI):
+        mock_client = MockOpenAI.return_value
+
+        mock_response = MagicMock()
+        mock_response.data[0].url = "http://image.url"
+        mock_client.images.generate.return_value = mock_response
+
+        gen = ContentGenerator(api_key="dummy_key")
+        url = gen.generate_art("A beautiful painting")
+
+        self.assertEqual(url, "http://image.url")
+        mock_client.images.generate.assert_called_once()
+        call_args = mock_client.images.generate.call_args[1]
+        self.assertEqual(call_args["model"], "dall-e-3")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/hymn_remaker/tests/test_midi_renderer.py
+++ b/hymn_remaker/tests/test_midi_renderer.py
@@ -1,0 +1,48 @@
+import unittest
+import os
+import shutil
+import sys
+from unittest.mock import patch
+
+# Adjust path so we can import src
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from hymn_remaker.src.midi_renderer import MidiRenderer
+
+class TestMidiRenderer(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = os.path.dirname(__file__)
+        self.output_dir = os.path.join(self.test_dir, "output")
+        os.makedirs(self.output_dir, exist_ok=True)
+        # Create a dummy midi file for testing
+        self.midi_path = os.path.join(self.output_dir, "test.mid")
+        with open(self.midi_path, "wb") as f:
+            f.write(b'MThd\x00\x00\x00\x06\x00\x00\x00\x01\x00\x60')
+
+    def tearDown(self):
+        if os.path.exists(self.output_dir):
+            shutil.rmtree(self.output_dir)
+
+    @patch('hymn_remaker.src.midi_renderer.FluidSynth')
+    def test_render_calls_midi_to_audio(self, MockFluidSynth):
+        # Setup mock
+        mock_fs_instance = MockFluidSynth.return_value
+
+        renderer = MidiRenderer()
+        output_path = os.path.join(self.output_dir, "test.wav")
+
+        renderer.render(self.midi_path, output_path)
+
+        mock_fs_instance.midi_to_audio.assert_called_once_with(self.midi_path, output_path)
+
+    def test_render_missing_midi(self):
+        # We don't need to patch here as it should fail before calling FluidSynth
+        # But MidiRenderer constructor calls FluidSynth so we still need to patch it or let it run (if fluidsynth installed)
+        # To be safe/fast, patch it.
+        with patch('hymn_remaker.src.midi_renderer.FluidSynth'):
+            renderer = MidiRenderer()
+            with self.assertRaises(FileNotFoundError):
+                renderer.render("non_existent.mid", "output.wav")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/hymn_remaker/tests/test_remaker.py
+++ b/hymn_remaker/tests/test_remaker.py
@@ -1,0 +1,46 @@
+import unittest
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from hymn_remaker.src.remaker import MusicRemaker
+
+class TestMusicRemaker(unittest.TestCase):
+    def setUp(self):
+        # Create a dummy audio file
+        self.audio_path = "test_input.wav"
+        with open(self.audio_path, "wb") as f:
+            f.write(b'RIFF....WAVEfmt ....data....')
+
+    def tearDown(self):
+        if os.path.exists(self.audio_path):
+            os.remove(self.audio_path)
+
+    @patch('hymn_remaker.src.remaker.replicate')
+    def test_remake_calls_replicate_run(self, mock_replicate):
+        mock_replicate.run.return_value = "http://example.com/remake.wav"
+
+        # Instantiate with a dummy token
+        remaker = MusicRemaker(api_token="dummy_token")
+
+        url = remaker.remake(self.audio_path, "Techno")
+
+        self.assertEqual(url, "http://example.com/remake.wav")
+        mock_replicate.run.assert_called_once()
+
+        # Verify the args passed to run
+        args, kwargs = mock_replicate.run.call_args
+        self.assertIn("meta/musicgen", args[0])
+        self.assertIn("prompt", kwargs['input'])
+        self.assertEqual(kwargs['input']['prompt'], "Techno")
+
+    def test_missing_token_warning(self):
+        with patch.dict(os.environ, {}, clear=True):
+            # This should log a warning but not crash init
+            remaker = MusicRemaker()
+            self.assertIsNone(remaker.api_token)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/hymn_remaker/tests/test_utils.py
+++ b/hymn_remaker/tests/test_utils.py
@@ -1,0 +1,40 @@
+import unittest
+from unittest.mock import MagicMock
+from hymn_remaker.src.utils import retry_request
+
+class TestUtils(unittest.TestCase):
+    def test_retry_success(self):
+        mock_func = MagicMock(return_value="success")
+        mock_func.__name__ = "mock_func"
+        decorated = retry_request(max_retries=2, delay=0)(mock_func)
+
+        result = decorated()
+
+        self.assertEqual(result, "success")
+        mock_func.assert_called_once()
+
+    def test_retry_fail_then_success(self):
+        # Fail twice then succeed
+        mock_func = MagicMock(side_effect=[Exception("fail1"), Exception("fail2"), "success"])
+        mock_func.__name__ = "mock_func"
+        decorated = retry_request(max_retries=2, delay=0)(mock_func)
+
+        result = decorated()
+
+        self.assertEqual(result, "success")
+        self.assertEqual(mock_func.call_count, 3)
+
+    def test_retry_fail_max(self):
+        # Fail always
+        mock_func = MagicMock(side_effect=Exception("fail"))
+        mock_func.__name__ = "mock_func"
+        decorated = retry_request(max_retries=2, delay=0)(mock_func)
+
+        with self.assertRaises(Exception):
+            decorated()
+
+        # Called once + 2 retries = 3 calls
+        self.assertEqual(mock_func.call_count, 3)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/hymn_remaker/tests/test_video_uploader.py
+++ b/hymn_remaker/tests/test_video_uploader.py
@@ -1,0 +1,44 @@
+import unittest
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from hymn_remaker.src.video_uploader import VideoProducer
+
+class TestVideoProducer(unittest.TestCase):
+    def setUp(self):
+        self.test_audio = "test_audio.wav"
+        with open(self.test_audio, "w") as f:
+            f.write("dummy audio")
+
+    def tearDown(self):
+        if os.path.exists(self.test_audio):
+            os.remove(self.test_audio)
+        if os.path.exists("test_video.mp4"):
+            os.remove("test_video.mp4")
+
+    @patch('hymn_remaker.src.video_uploader.requests.get')
+    @patch('hymn_remaker.src.video_uploader.subprocess.run')
+    def test_create_video(self, mock_subprocess, mock_get):
+        # Mock requests.get
+        mock_response = MagicMock()
+        mock_response.content = b"fake image content"
+        mock_get.return_value = mock_response
+
+        producer = VideoProducer()
+        output_path = "test_video.mp4"
+
+        producer.create_video(self.test_audio, "http://image.url", output_path)
+
+        mock_get.assert_called_with("http://image.url")
+        mock_subprocess.assert_called_once()
+
+        cmd = mock_subprocess.call_args[0][0]
+        self.assertEqual(cmd[0], "ffmpeg")
+        self.assertIn("-loop", cmd)
+        self.assertIn("-shortest", cmd)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This submission implements a complete pipeline to transform public domain hymn MIDI files into Deep House remixes, generate associated metadata and album art, create a video, and upload it to YouTube.

Key components:
1.  **MidiRenderer**: Renders MIDI files to audio using `fluidsynth`.
2.  **MusicRemaker**: Uses Replicate's `musicgen` model to generate a remix conditioned on the rendered audio.
3.  **ContentGenerator**: Generates video titles, descriptions, and tags using GPT-4, and album art using DALL-E 3.
4.  **VideoProducer**: Combines the remix audio and album art into an MP4 video using `ffmpeg` and uploads it to YouTube using the Google API.
5.  **Orchestrator**: `main.py` manages the workflow, processing all MIDI files in the input directory.

Dependencies are listed in `requirements.txt`. Configuration is handled via environment variables.

---
*PR created automatically by Jules for task [2252131534960899343](https://jules.google.com/task/2252131534960899343) started by @robertpelloni*